### PR TITLE
Feature/update koe

### DIFF
--- a/src/aquestalk.rs
+++ b/src/aquestalk.rs
@@ -25,7 +25,7 @@ mod dll;
 use dll::AquesTalkDll;
 
 mod koe;
-pub use koe::{Koe, KoeError};
+pub use koe::Koe;
 
 #[derive(Debug, Clone)]
 pub struct AquesTalk(Arc<Mutex<AquesTalkDll>>);

--- a/src/server.rs
+++ b/src/server.rs
@@ -135,8 +135,8 @@ impl AquesTalkProxyServer {
             };
             let koe = match Koe::from_str(req.koe()) {
                 Ok(koe) => koe,
-                Err(ref err) => {
-                    serde_json::to_writer(&stream, &Res::from_error(err))?;
+                Err(err) => {
+                    serde_json::to_writer(&stream, &Res::from(err))?;
                     continue;
                 }
             };


### PR DESCRIPTION
KoeError をやめて AquesTalk::Error に統一する