### PR TITLE
Feature/koe test

### DIFF
--- a/src/aquestalk/koe.rs
+++ b/src/aquestalk/koe.rs
@@ -57,3 +57,29 @@ impl FromStr for Koe {
         Ok(Koe(koe))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use encoding_rs::SHIFT_JIS;
+
+    use std::{ffi::CString, str::FromStr};
+
+    use super::Koe;
+    use crate::aquestalk::{load_libs, Error as AquesTalkError, Wav};
+
+    fn aqtk_synthe(koe: &str) -> Result<Wav, AquesTalkError> {
+        let (koe, _, had_errors) = SHIFT_JIS.encode(koe);
+        assert!(!had_errors);
+        let libs = load_libs(&"./aquestalk").unwrap();
+        let f1 = libs.get("f1").unwrap();
+
+        unsafe { f1.synthe_raw(&CString::new(koe).unwrap(), 100) }
+    }
+
+    #[test]
+    fn test_koe_space() {
+        let aqtk_err = aqtk_synthe("　");
+        let koe_err = Koe::from_str(" ");
+        assert_eq!(aqtk_err.err().unwrap(), koe_err.err().unwrap());
+    }
+}

--- a/src/aquestalk/koe.rs
+++ b/src/aquestalk/koe.rs
@@ -82,4 +82,15 @@ mod test {
         let koe_err = Koe::from_str(" ");
         assert_eq!(aqtk_err.err().unwrap(), koe_err.err().unwrap());
     }
+
+    #[test]
+    fn test_koe_non_shiftjis_char() {
+        let test_str = "🤔";
+
+        let libs = load_libs(&"./aquestalk").unwrap();
+        let f1 = libs.get("f1").unwrap();
+        let aqtk_err = unsafe { f1.synthe_raw(&CString::new(test_str).unwrap(), 100) };
+        let koe_err = Koe::from_str(test_str);
+        assert_eq!(aqtk_err.err().unwrap(), koe_err.err().unwrap());
+    }
 }

--- a/src/aquestalk/koe.rs
+++ b/src/aquestalk/koe.rs
@@ -93,4 +93,13 @@ mod test {
         let koe_err = Koe::from_str(test_str);
         assert_eq!(aqtk_err.err().unwrap(), koe_err.err().unwrap());
     }
+
+    #[test]
+    fn test_koe_long_accent_phrase() {
+        let test_str = "あ".repeat(256);
+
+        let aqtk_err = aqtk_synthe(&test_str);
+        let koe_err = Koe::from_str(&test_str);
+        assert_eq!(aqtk_err.err().unwrap(), koe_err.err().unwrap());
+    }
 }


### PR DESCRIPTION
Koe::from_str にテストを追加

AquesTalk がクラッシュする文字列は弾くようにした