### PR TITLE
Feature/update messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "encoding_rs",
  "getopts",
  "libloading",
+ "optional_take",
  "serde",
  "serde_json",
  "threadpool",
@@ -85,6 +86,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "optional_take"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2aac37449d65494c882cf25339ae9f4bef4f21660469dfd1a5f704f95ae73b"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.13"
 encoding_rs = "0.8"
 getopts = "0.2.21"
 libloading = "0.7"
+optional_take = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 threadpool = "1.8"

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@
 // along with AquesTalk-proxy.  If not, see <https://www.gnu.org/licenses/>.
 
 mod connection;
-pub mod messages;
+mod messages;
 
 use std::collections::HashMap;
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -8,6 +8,19 @@ use crate::aquestalk::AquesTalk;
 
 use super::messages::{Request, Response, ResponseImpl};
 
+pub fn new_voice_type_error(voice_type: String) -> ResponseImpl {
+    ResponseImpl::AquestalkError {
+        code: None,
+        message: format!("不明な声種 ({})", voice_type),
+    }
+}
+
+pub fn new_limit_reached_error() -> ResponseImpl {
+    ResponseImpl::ConnectionError {
+        message: "Request is too long".to_string(),
+    }
+}
+
 pub fn handle_connection<R, W>(
     reader: R,
     mut writer: W,
@@ -26,7 +39,7 @@ where
             Ok(req) => req,
             Err(err) => {
                 let response = if err.is_eof() && reader.limit() == Some(0) {
-                    ResponseImpl::new_limit_reached_error()
+                    new_limit_reached_error()
                 } else {
                     ResponseImpl::from(err)
                 };
@@ -51,7 +64,7 @@ where
                     &Response {
                         is_connection_reusable: true,
                         is_success: false,
-                        response: ResponseImpl::new_voice_type_error(req.voice_type),
+                        response: new_voice_type_error(req.voice_type),
                     },
                 )?;
                 continue;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -195,7 +195,7 @@ mod test {
               "isSuccess": false,
               "response": {
                 "type": "AquestalkError",
-                "message": "不明な声質 (invalid type)"
+                "message": "不明な声種 (invalid type)"
               }
             }
             )

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -5,7 +5,7 @@ use serde_json::Deserializer;
 
 use crate::aquestalk::AquesTalk;
 
-use super::messages::{Req, Res};
+use super::messages::{Request, Response, ResponseImpl};
 
 pub fn handle_connection<R, W>(
     reader: R,
@@ -53,7 +53,8 @@ where
 #[cfg(test)]
 mod test {
     use super::handle_connection;
-    use crate::{aquestalk::load_libs, server::messages::Res};
+    use crate::aquestalk::load_libs;
+    use crate::server::messages::{Response, ResponseImpl};
 
     #[test]
     fn test_connection() {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -144,8 +144,8 @@ mod test {
               "isConnectionReusable": false,
               "isSuccess": false,
               "response": {
-                "type": "JsonError",
-                "message": "EOF while parsing an object at line 1 column 37"
+                "type": "ConnectionError",
+                "message": "Request is too long"
               }
             }
             )

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -63,10 +63,12 @@ mod test {
         let mut output = Vec::new();
 
         handle_connection(input, &mut output, libs, None).unwrap();
-        let output: Res = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+        let response: Response = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
 
-        match output {
-            Res::Success { wav: _ } => (),
+        assert!(response.is_connection_reusable);
+        assert!(response.is_success);
+        match response.response {
+            ResponseImpl::Wav { wav: _ } => (),
             _ => unreachable!(),
         };
     }
@@ -78,11 +80,12 @@ mod test {
         let mut output = Vec::new();
 
         handle_connection(input, &mut output, libs, Some(37)).unwrap();
-        let output: Res = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+        let response: Response = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
 
-        match output {
-            Res::Error { ref message, code } => {
-                assert_eq!(code, None);
+        assert!(!response.is_connection_reusable);
+        assert!(!response.is_success);
+        match response.response {
+            ResponseImpl::JsonError { ref message } => {
                 assert_eq!(message, "EOF while parsing an object at line 1 column 37");
             }
             _ => unreachable!(),
@@ -96,11 +99,12 @@ mod test {
         let mut output = Vec::new();
 
         handle_connection(input, &mut output, libs, None).unwrap();
-        let output: Res = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+        let response: Response = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
 
-        match output {
-            Res::Error { ref message, code } => {
-                assert_eq!(code, None);
+        assert!(!response.is_connection_reusable);
+        assert!(!response.is_success);
+        match response.response {
+            ResponseImpl::JsonError { ref message } => {
                 assert_eq!(message, "EOF while parsing an object at line 1 column 37");
             }
             _ => unreachable!(),
@@ -114,10 +118,12 @@ mod test {
         let mut output = Vec::new();
 
         handle_connection(input, &mut output, libs, None).unwrap();
-        let output: Res = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+        let response: Response = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
 
-        match output {
-            Res::Error { ref message, code } => {
+        assert!(response.is_connection_reusable);
+        assert!(!response.is_success);
+        match response.response {
+            ResponseImpl::AquestalkError { ref message, code } => {
                 assert_eq!(code, None);
                 assert_eq!(message, "不明な声質 (invalid type)");
             }
@@ -132,10 +138,12 @@ mod test {
         let mut output = Vec::new();
 
         handle_connection(input, &mut output, libs, None).unwrap();
-        let output: Res = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
+        let response: Response = serde_json::from_str(&String::from_utf8(output).unwrap()).unwrap();
 
-        match output {
-            Res::Error { ref message, code } => {
+        assert!(response.is_connection_reusable);
+        assert!(!response.is_success);
+        match response.response {
+            ResponseImpl::AquestalkError { ref message, code } => {
                 assert_eq!(code, Some(105));
                 assert_eq!(message, "音声記号列に未定義の読み記号が指定された");
             }

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -47,6 +47,27 @@ pub struct Response {
     pub response: ResponseImpl,
 }
 
+impl Response {
+    pub fn new(status: ResponseStatus, response: ResponseImpl) -> Self {
+        let (is_success, is_connection_reusable) = match status {
+            ResponseStatus::Success => (true, true),
+            ResponseStatus::Reusable => (false, true),
+            ResponseStatus::Failure => (false, false),
+        };
+        Self {
+            is_connection_reusable,
+            is_success,
+            response,
+        }
+    }
+}
+
+pub enum ResponseStatus {
+    Success,
+    Reusable,
+    Failure,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields, tag = "type")]
 pub enum ResponseImpl {

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -71,6 +71,12 @@ impl ResponseImpl {
             message: format!("不明な声質 ({})", voice_type),
         }
     }
+
+    pub fn new_limit_reached_error() -> Self {
+        ResponseImpl::ConnectionError {
+            message: "Request is too long".to_string(),
+        }
+    }
 }
 
 impl From<Wav> for ResponseImpl {

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -70,7 +70,7 @@ impl ResponseImpl {
     pub fn new_voice_type_error(voice_type: String) -> Self {
         ResponseImpl::AquestalkError {
             code: None,
-            message: format!("不明な声質 ({})", voice_type),
+            message: format!("不明な声種 ({})", voice_type),
         }
     }
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with AquesTalk-proxy.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::io;
+
 use serde::{Deserialize, Serialize};
 
 use crate::aquestalk::Wav;
@@ -98,8 +100,15 @@ impl From<crate::aquestalk::Error> for ResponseImpl {
 
 impl From<serde_json::Error> for ResponseImpl {
     fn from(err: serde_json::Error) -> Self {
-        ResponseImpl::JsonError {
-            message: err.to_string(),
+        if !err.is_io() {
+            ResponseImpl::JsonError {
+                message: err.to_string(),
+            }
+        } else {
+            let err: io::Error = err.into();
+            ResponseImpl::ConnectionError {
+                message: err.to_string(),
+            }
         }
     }
 }

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -18,6 +18,7 @@
 use std::io;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::aquestalk::Wav;
 
@@ -45,10 +46,12 @@ pub struct Response {
     pub is_success: bool,
     pub is_connection_reusable: bool,
     pub response: ResponsePayload,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request: Option<Value>,
 }
 
 impl Response {
-    pub fn new(status: ResponseStatus, payload: ResponsePayload) -> Self {
+    pub fn new(status: ResponseStatus, payload: ResponsePayload, request: Option<Value>) -> Self {
         let (is_success, is_connection_reusable) = match status {
             ResponseStatus::Success => (true, true),
             ResponseStatus::Reusable => (false, true),
@@ -58,6 +61,7 @@ impl Response {
             is_connection_reusable,
             is_success,
             response: payload,
+            request,
         }
     }
 }

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -66,21 +66,6 @@ pub enum ResponseImpl {
     },
 }
 
-impl ResponseImpl {
-    pub fn new_voice_type_error(voice_type: String) -> Self {
-        ResponseImpl::AquestalkError {
-            code: None,
-            message: format!("不明な声種 ({})", voice_type),
-        }
-    }
-
-    pub fn new_limit_reached_error() -> Self {
-        ResponseImpl::ConnectionError {
-            message: "Request is too long".to_string(),
-        }
-    }
-}
-
 impl From<Wav> for ResponseImpl {
     fn from(wav: Wav) -> Self {
         ResponseImpl::Wav {


### PR DESCRIPTION
メッセージの形式を変更した

# Before

エラーが発生した場合に、次のリクエストが受付可能かがわからなかった。

```ts
type Result =
    | {
          type: "success"; // 成功した場合
          wav: string; // WAV データ、Base64 エンコード
      }
    | {
          type: "error"; // エラーが発生した場合
          code?: number; // エラーコード (AquesTalk ライブラリ内でエラーが発生した場合)
          message: string; // エラーメッセージ
      };
```

# After

`isConnectionReusable` を追加し、現在の接続が使用可能かを応答に含める。

`request` を追加し、現在の応答がどのリクエストに対するものかを明確にする。

```ts
type Result = {
    isSuccess: boolean; // リクエストの結果が成功かどうか
    isConnectionReusable: boolean; // 続けて新たなリクエストが可能かどうか
    response:
        | { type: "Wav"; wav: string } // WAV データ、Base64 エンコード
        | {
              type: "AquestalkError"; // AquesTalk ライブラリ内でエラーが発生した場合
              code?: number; // エラーコード (AquesTalk ライブラリ内でエラーが発生した場合)
              message: string; // エラーメッセージ
          }
        | {
              type: "JsonError"; // リクエストのパース中にエラーが発生した場合
              message: String; // エラーメッセージ
          }
        | {
              type: "ConnectionError"; // 接続関連のエラー
              message: String; // エラーメッセージ
          };
    request?: any; // 対応するリクエスト (JSON構文エラーまたは接続エラーが発生しなかった場合)
};
```
